### PR TITLE
Fix syntax error on Xcode 6 beta 4

### DIFF
--- a/Classes/SCLAlertView.swift
+++ b/Classes/SCLAlertView.swift
@@ -262,15 +262,15 @@ class SCLAlertViewStyleKit : NSObject {
     
     struct Cache {
         static var imageOfCheckmark: UIImage?
-        static var checkmarkTargets: AnyObject[]?
+        static var checkmarkTargets: [AnyObject]?
         static var imageOfCross: UIImage?
-        static var crossTargets: AnyObject[]?
+        static var crossTargets: [AnyObject]?
         static var imageOfNotice: UIImage?
-        static var noticeTargets: AnyObject[]?
+        static var noticeTargets: [AnyObject]?
         static var imageOfWarning: UIImage?
-        static var warningTargets: AnyObject[]?
+        static var warningTargets: [AnyObject]?
         static var imageOfInfo: UIImage?
-        static var infoTargets: AnyObject[]?
+        static var infoTargets: [AnyObject]?
     }
     
     //// Initialization


### PR DESCRIPTION
Array types are now written with the brackets around the element type
