### PR TITLE
Added touch event highlighting to buttons for better user interactions

### DIFF
--- a/Classes/SCLAlertView.swift
+++ b/Classes/SCLAlertView.swift
@@ -81,6 +81,10 @@ class SCLAlertView: UIViewController {
     let kDefaultFont = "HelveticaNeue"
 	let kButtonFont = "HelveticaNeue-Bold"
 	
+	// UI Colour	
+    var viewColor = UIColor()
+    var pressBrightnessFactor = 0.85
+
     // Members declaration
     var labelTitle = UILabel()
     var viewText = UITextView()
@@ -212,6 +216,8 @@ class SCLAlertView: UIViewController {
 		btn.actionType = SCLActionType.Closure
 		btn.action = action
 		btn.addTarget(self, action:Selector("buttonTapped:"), forControlEvents:.TouchUpInside)
+        btn.addTarget(self, action:Selector("buttonTapDown:"), forControlEvents:.TouchDown | .TouchDragEnter)
+        btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:.TouchUpInside | .TouchUpOutside | .TouchCancel | .TouchDragOutside )
 		return btn
 	}
 	
@@ -221,6 +227,8 @@ class SCLAlertView: UIViewController {
 		btn.target = target
 		btn.selector = selector
 		btn.addTarget(self, action:Selector("buttonTapped:"), forControlEvents:.TouchUpInside)
+        btn.addTarget(self, action:Selector("buttonTapDown:"), forControlEvents:.TouchDown | .TouchDragEnter)
+        btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:.TouchUpInside | .TouchUpOutside | .TouchCancel | .TouchDragOutside )
 		return btn
 	}
 	
@@ -248,6 +256,22 @@ class SCLAlertView: UIViewController {
 		}
 		hideView()
 	}
+	
+
+	func buttonTapDown(btn:SCLButton) {
+        var hue : CGFloat = 0
+        var saturation : CGFloat = 0
+        var brightness : CGFloat = 0
+        var alpha : CGFloat = 0
+        btn.backgroundColor?.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+        brightness = brightness * CGFloat(pressBrightness)
+        btn.backgroundColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: alpha)
+    }
+    
+    func buttonRelease(btn:SCLButton) {
+        btn.backgroundColor = viewColor
+    }
+	
 	
 	// showSuccess(view, title, subTitle)
 	func showSuccess(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0) -> SCLAlertViewResponder {
@@ -291,7 +315,7 @@ class SCLAlertView: UIViewController {
 		view.frame = rv.bounds
 		
         // Alert colour/icon
-        var viewColor = UIColor()
+        viewColor = UIColor()
         var iconImage: UIImage
         
         // Icon style


### PR DESCRIPTION
Added touch event highlighting to buttons for better user interactions

The background colour brightness (HSB) is changed according to the variable `pressBrightnessFactor` in SCLAertView.swift

Added two button targets

1. to darken button on touches
  `btn.addTarget(self, action:Selector("buttonTapDown:"), forControlEvents:.TouchDown | .TouchDragEnter)`

2. to return to normal colour
  `btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:.TouchUpInside | .TouchUpOutside | .TouchCancel | .TouchDragOutside)`

This is my first pull request so let me know if I need to do anything else
