### PR TITLE
AppDelegate `application(_:didFinishLaunchingWithOptions:)` did change

### DIFF
--- a/Classes/SCLAlertView.swift
+++ b/Classes/SCLAlertView.swift
@@ -26,7 +26,7 @@ public class SCLButton: UIButton {
     var selector:Selector!
     var action:(()->Void)!
 
-    override init() {
+    override public init() {
         super.init()
     }
 

--- a/Classes/SCLAlertView.swift
+++ b/Classes/SCLAlertView.swift
@@ -26,7 +26,7 @@ public class SCLButton: UIButton {
     var selector:Selector!
     var action:(()->Void)!
 
-    override public init() {
+    override init() {
         super.init()
     }
 

--- a/Example/SCLAlertViewExample/AppDelegate.swift
+++ b/Example/SCLAlertViewExample/AppDelegate.swift
@@ -13,8 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             
     var window: UIWindow?
 
-
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
#### Description
Resolves build issues in Xcode 6.2 (6C131e) resulting from the change of `application(_:didFinishLaunchingWithOptions:)`

#### Testing
Project should build and run successfully under Xcode 6.2 (6C131e). 