### PR TITLE
Show alert on last view not first view

### DIFF
--- a/Classes/SCLAlertView.swift
+++ b/Classes/SCLAlertView.swift
@@ -322,7 +322,7 @@ public class SCLAlertView: UIViewController {
     // showTitle(view, title, subTitle, duration, style)
     public func showTitle(title: String, subTitle: String, duration: NSTimeInterval?, completeText: String?, style: SCLAlertViewStyle) -> SCLAlertViewResponder {
         view.alpha = 0
-        let rv = UIApplication.sharedApplication().keyWindow?.subviews.first as! UIView
+        let rv = UIApplication.sharedApplication().keyWindow?.subviews.last as! UIView
         rv.addSubview(view)
         view.frame = rv.bounds
         baseView.frame = rv.bounds


### PR DESCRIPTION
@zhjuncai added a fix that was needed in my situation. My alert would never show, switching from first to last it then would display. His commit added feature so I left that out as it created issues with my application crashing when no completetxt was provided, and the user touched outside the alert.

https://github.com/zhjuncai/SCLAlertView-Swift/commit/28c9135e61ce82e8a945dcce94f1259881b1cf51