### PR TITLE
Fade-out animation bug fixed

### DIFF
--- a/Example/SCLAlertViewExample/SCLAlertView.swift
+++ b/Example/SCLAlertViewExample/SCLAlertView.swift
@@ -259,6 +259,7 @@ public class SCLAlertView: UIViewController {
         } else if btn.actionType == SCLActionType.Selector {
             let ctrl = UIControl()
             ctrl.sendAction(btn.selector, to:btn.target, forEvent:nil)
+            return
         } else {
             println("Unknow action type for button")
         }

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -260,6 +260,7 @@ public class SCLAlertView: UIViewController {
         } else if btn.actionType == SCLActionType.Selector {
             let ctrl = UIControl()
             ctrl.sendAction(btn.selector, to:btn.target, forEvent:nil)
+            return
         } else {
             println("Unknow action type for button")
         }


### PR DESCRIPTION
There is a little bug. When you tap the done button, the fade-out animation won't work. The alert view will disappear immediately. I fixed this by adding a return.