### PR TITLE
Done fade-out animation bug fixed

### DIFF
--- a/Example/SCLAlertViewExample/SCLAlertView.swift
+++ b/Example/SCLAlertViewExample/SCLAlertView.swift
@@ -259,6 +259,7 @@ public class SCLAlertView: UIViewController {
         } else if btn.actionType == SCLActionType.Selector {
             let ctrl = UIControl()
             ctrl.sendAction(btn.selector, to:btn.target, forEvent:nil)
+            return
         } else {
             println("Unknow action type for button")
         }

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -284,6 +284,7 @@ public class SCLAlertView: UIViewController {
         } else if btn.actionType == SCLActionType.Selector {
             let ctrl = UIControl()
             ctrl.sendAction(btn.selector, to:btn.target, forEvent:nil)
+            return
         } else {
             println("Unknow action type for button")
         }


### PR DESCRIPTION
There was a little bug. when you tap the done button, the fade-out animation doesn’t work. I fixed this by adding a return.