### PR TITLE
Update for split-screen multitasking on iOS 9

### DIFF
--- a/Example/SCLAlertViewExample/Info.plist
+++ b/Example/SCLAlertViewExample/Info.plist
@@ -40,5 +40,18 @@
 			<false/>
 		</dict>
 	</dict>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
 </dict>
 </plist>

--- a/Example/SCLAlertViewExample/SCLAlertView.swift
+++ b/Example/SCLAlertViewExample/SCLAlertView.swift
@@ -25,15 +25,15 @@ public class SCLButton: UIButton {
     var target:AnyObject!
     var selector:Selector!
     var action:(()->Void)!
-
+    
     public init() {
         super.init(frame: CGRectZero)
     }
-
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder:aDecoder)
     }
-
+    
     override public init(frame:CGRect) {
         super.init(frame:frame)
     }
@@ -43,20 +43,20 @@ public class SCLButton: UIButton {
 // Example: SCLAlertView().showSuccess(self, title: "Test", subTitle: "Value").close()
 public class SCLAlertViewResponder {
     let alertview: SCLAlertView
-
+    
     // Initialisation and Title/Subtitle/Close functions
     public init(alertview: SCLAlertView) {
         self.alertview = alertview
     }
-
+    
     public func setTitle(title: String) {
         self.alertview.labelTitle.text = title
     }
-
+    
     public func setSubTitle(subTitle: String) {
         self.alertview.viewText.text = subTitle
     }
-
+    
     public func close() {
         self.alertview.hideView()
     }
@@ -76,18 +76,20 @@ public class SCLAlertView: UIViewController {
     let kWindowWidth: CGFloat = 240.0
     var kWindowHeight: CGFloat = 178.0
     var kTextHeight: CGFloat = 90.0
-
+    let kTextFieldHeight: CGFloat = 45.0
+    let kButtonHeight: CGFloat = 45.0
+    
     // Font
     let kDefaultFont = "HelveticaNeue"
     let kButtonFont = "HelveticaNeue-Bold"
-
+    
     // UI Colour
     var viewColor = UIColor()
     var pressBrightnessFactor = 0.85
     
     // UI Options
-    var showCloseButton = true
-
+    public var showCloseButton = true
+    
     // Members declaration
     var baseView = UIView()
     var labelTitle = UILabel()
@@ -99,11 +101,12 @@ public class SCLAlertView: UIViewController {
     var durationTimer: NSTimer!
     private var inputs = [UITextField]()
     private var buttons = [SCLButton]()
+    private var selfReference: SCLAlertView?
     
     required public init?(coder aDecoder: NSCoder) {
         fatalError("NSCoding not supported")
     }
-
+    
     required public init() {
         super.init(nibName:nil, bundle:nil)
         // Set up main view
@@ -150,11 +153,11 @@ public class SCLAlertView: UIViewController {
         tapGesture.numberOfTapsRequired = 1
         self.view.addGestureRecognizer(tapGesture)
     }
-
+    
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
         super.init(nibName:nibNameOrNil, bundle:nibBundleOrNil)
     }
-
+    
     override public func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         var sz = UIScreen.mainScreen().bounds.size
@@ -169,28 +172,50 @@ public class SCLAlertView: UIViewController {
         }
         // Set background frame
         view.frame.size = sz
+        
+        // computing the right size to use for the textView
+        let maxHeight = sz.height - 100 // max overall height
+        var consumedHeight = CGFloat(0)
+        consumedHeight += kTitleTop + kTitleHeight
+        consumedHeight += 14
+        consumedHeight += kButtonHeight * CGFloat(buttons.count)
+        consumedHeight += kTextFieldHeight * CGFloat(inputs.count)
+        let maxViewTextHeight = maxHeight - consumedHeight
+        let viewTextWidth = kWindowWidth - 24
+        let suggestedViewTextSize = viewText.sizeThatFits(CGSizeMake(viewTextWidth, CGFloat.max))
+        let viewTextHeight = min(suggestedViewTextSize.height, maxViewTextHeight)
+        
+        // scroll management
+        if (suggestedViewTextSize.height > maxViewTextHeight) {
+            viewText.scrollEnabled = true
+        } else {
+            viewText.scrollEnabled = false
+        }
+        
+        let windowHeight = consumedHeight + viewTextHeight
         // Set frames
         var x = (sz.width - kWindowWidth) / 2
-        var y = (sz.height - kWindowHeight -  (kCircleHeight / 8)) / 2
-        contentView.frame = CGRect(x:x, y:y, width:kWindowWidth, height:kWindowHeight)
+        var y = (sz.height - windowHeight - (kCircleHeight / 8)) / 2
+        contentView.frame = CGRect(x:x, y:y, width:kWindowWidth, height:windowHeight)
         y -= kCircleHeightBackground * 0.6
         x = (sz.width - kCircleHeightBackground) / 2
         circleBG.frame = CGRect(x:x, y:y+6, width:kCircleHeightBackground, height:kCircleHeightBackground)
         // Subtitle
         y = kTitleTop + kTitleHeight
         viewText.frame = CGRect(x:12, y:y, width: kWindowWidth - 24, height:kTextHeight)
+        viewText.frame = CGRect(x:12, y:y, width: viewTextWidth, height:viewTextHeight)
         // Text fields
-        y += kTextHeight + 14.0
+        y += viewTextHeight + 14.0
         for txt in inputs {
             txt.frame = CGRect(x:12, y:y, width:kWindowWidth - 24, height:30)
             txt.layer.cornerRadius = 3
-            y += 40
+            y += kTextFieldHeight
         }
         // Buttons
         for btn in buttons {
             btn.frame = CGRect(x:12, y:y, width:kWindowWidth - 24, height:35)
             btn.layer.cornerRadius = 3
-            y += 45.0
+            y += kButtonHeight
         }
     }
     
@@ -199,10 +224,10 @@ public class SCLAlertView: UIViewController {
             view.endEditing(true)
         }
     }
-
+    
     public func addTextField(title:String?=nil)->UITextField {
         // Update view height
-        kWindowHeight += 40.0
+        kWindowHeight += kTextFieldHeight
         // Add text field
         let txt = UITextField()
         txt.borderStyle = UITextBorderStyle.RoundedRect
@@ -218,7 +243,7 @@ public class SCLAlertView: UIViewController {
         inputs.append(txt)
         return txt
     }
-
+    
     public func addButton(title:String, action:()->Void)->SCLButton {
         let btn = addButton(title)
         btn.actionType = SCLActionType.Closure
@@ -228,7 +253,7 @@ public class SCLAlertView: UIViewController {
         btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:[.TouchUpInside, .TouchUpOutside, .TouchCancel, .TouchDragOutside] )
         return btn
     }
-
+    
     public func addButton(title:String, target:AnyObject, selector:Selector)->SCLButton {
         let btn = addButton(title)
         btn.actionType = SCLActionType.Selector
@@ -239,10 +264,10 @@ public class SCLAlertView: UIViewController {
         btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:[.TouchUpInside, .TouchUpOutside, .TouchCancel, .TouchDragOutside] )
         return btn
     }
-
+    
     private func addButton(title:String)->SCLButton {
         // Update view height
-        kWindowHeight += 45.0
+        kWindowHeight += kButtonHeight
         // Add button
         let btn = SCLButton()
         btn.layer.masksToBounds = true
@@ -252,7 +277,7 @@ public class SCLAlertView: UIViewController {
         buttons.append(btn)
         return btn
     }
-
+    
     func buttonTapped(btn:SCLButton) {
         if btn.actionType == SCLActionType.Closure {
             btn.action()
@@ -265,8 +290,8 @@ public class SCLAlertView: UIViewController {
         }
         hideView()
     }
-
-
+    
+    
     func buttonTapDown(btn:SCLButton) {
         var hue : CGFloat = 0
         var saturation : CGFloat = 0
@@ -276,7 +301,7 @@ public class SCLAlertView: UIViewController {
         //brightness = brightness * CGFloat(pressBrightness)
         btn.backgroundColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: alpha)
     }
-
+    
     func buttonRelease(btn:SCLButton) {
         btn.backgroundColor = viewColor
     }
@@ -285,114 +310,115 @@ public class SCLAlertView: UIViewController {
     func dismissKeyboard(){
         self.view.endEditing(true)
     }
-
+    
     // showSuccess(view, title, subTitle)
     public func showSuccess(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt=0x22B573, colorTextButton: UInt=0xFFFFFF) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Success, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-
+    
     // showError(view, title, subTitle)
     public func showError(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt=0xC1272D, colorTextButton: UInt=0xFFFFFF) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Error, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-
+    
     // showNotice(view, title, subTitle)
     public func showNotice(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt=0x727375, colorTextButton: UInt=0xFFFFFF) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Notice, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-
+    
     // showWarning(view, title, subTitle)
     public func showWarning(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt=0xFFD110, colorTextButton: UInt=0x000000) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Warning, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-
+    
     // showInfo(view, title, subTitle)
     public func showInfo(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt=0x2866BF, colorTextButton: UInt=0xFFFFFF) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Info, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-
+    
     // showWait(view, title, subTitle)
     public func showWait(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt?=0xD62DA5, colorTextButton: UInt=0xFFFFFF) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Wait, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-  
+    
     public func showEdit(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt=0xA429FF, colorTextButton: UInt=0xFFFFFF) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Edit, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-
+    
     // showTitle(view, title, subTitle, style)
     public func showTitle(title: String, subTitle: String, style: SCLAlertViewStyle, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt?, colorTextButton: UInt=0xFFFFFF) -> SCLAlertViewResponder {
         return showTitle(title, subTitle: subTitle, duration:duration, completeText:closeButtonTitle, style: style, colorStyle: colorStyle, colorTextButton: colorTextButton)
     }
-
+    
     // showTitle(view, title, subTitle, duration, style)
     public func showTitle(title: String, subTitle: String, duration: NSTimeInterval?, completeText: String?, style: SCLAlertViewStyle, colorStyle: UInt?, colorTextButton: UInt?) -> SCLAlertViewResponder {
+        selfReference = self
         view.alpha = 0
         let rv = UIApplication.sharedApplication().keyWindow! as UIWindow
         rv.addSubview(view)
         view.frame = rv.bounds
         baseView.frame = rv.bounds
-
+        
         // Alert colour/icon
         viewColor = UIColor()
         var iconImage: UIImage?
-
+        
         // Icon style
         switch style {
         case .Success:
             viewColor = UIColorFromRGB(colorStyle!)
             iconImage = SCLAlertViewStyleKit.imageOfCheckmark
-
+            
         case .Error:
             viewColor = UIColorFromRGB(colorStyle!)
             iconImage = SCLAlertViewStyleKit.imageOfCross
-
+            
         case .Notice:
             viewColor = UIColorFromRGB(colorStyle!)
             iconImage = SCLAlertViewStyleKit.imageOfNotice
-
+            
         case .Warning:
             viewColor = UIColorFromRGB(colorStyle!)
             iconImage = SCLAlertViewStyleKit.imageOfWarning
-
+            
         case .Info:
             viewColor = UIColorFromRGB(colorStyle!)
             iconImage = SCLAlertViewStyleKit.imageOfInfo
-
+            
         case .Edit:
             viewColor = UIColorFromRGB(colorStyle!)
             iconImage = SCLAlertViewStyleKit.imageOfEdit
-
+            
         case .Wait:
             viewColor = UIColorFromRGB(colorStyle!)
         }
-
+        
         // Title
         if !title.isEmpty {
             self.labelTitle.text = title
         }
-
+        
         // Subtitle
         if !subTitle.isEmpty {
             viewText.text = subTitle
             // Adjust text view size, if necessary
             let str = subTitle as NSString
-            let attr = [NSFontAttributeName:viewText.font] as [String: AnyObject!]
+            let attr = [NSFontAttributeName:viewText.font ?? UIFont()]
             let sz = CGSize(width: kWindowWidth - 24, height:90)
-            let r = str.boundingRectWithSize(sz, options: NSStringDrawingOptions.UsesLineFragmentOrigin, attributes: attr, context: nil)
+            let r = str.boundingRectWithSize(sz, options: NSStringDrawingOptions.UsesLineFragmentOrigin, attributes:attr, context:nil)
             let ht = ceil(r.size.height)
             if ht < kTextHeight {
                 kWindowHeight -= (kTextHeight - ht)
                 kTextHeight = ht
             }
         }
-
+        
         // Done button
         if showCloseButton {
             let txt = completeText != nil ? completeText! : "Done"
             addButton(txt, target:self, selector:Selector("hideView"))
         }
-
+        
         // Alert view colour and images
         circleView.backgroundColor = viewColor
         // Spinner / icon
@@ -407,7 +433,7 @@ public class SCLAlertView: UIViewController {
         circleView.addSubview(circleIconView!)
         let x = (kCircleHeight - kCircleIconHeight) / 2
         circleIconView!.frame = CGRectMake( x, x, kCircleIconHeight, kCircleIconHeight)
-
+        
         for txt in inputs {
             txt.layer.borderColor = viewColor.CGColor
         }
@@ -415,13 +441,13 @@ public class SCLAlertView: UIViewController {
             btn.backgroundColor = viewColor
             btn.setTitleColor(UIColorFromRGB(colorTextButton!), forState:UIControlState.Normal)
         }
-
+        
         // Adding duration
         if duration > 0 {
             durationTimer?.invalidate()
             durationTimer = NSTimer.scheduledTimerWithTimeInterval(duration!, target: self, selector: Selector("hideView"), userInfo: nil, repeats: false)
         }
-
+        
         // Animate in the alert view
         self.baseView.frame.origin.y = -400
         UIView.animateWithDuration(0.2, animations: {
@@ -435,16 +461,17 @@ public class SCLAlertView: UIViewController {
         // Chainable objects
         return SCLAlertViewResponder(alertview: self)
     }
-
+    
     // Close SCLAlertView
     public func hideView() {
         UIView.animateWithDuration(0.2, animations: {
             self.view.alpha = 0
             }, completion: { finished in
                 self.view.removeFromSuperview()
+                self.selfReference = nil
         })
     }
-
+    
     // Helper function to convert from RGB to UIColor
     func UIColorFromRGB(rgbValue: UInt) -> UIColor {
         return UIColor(
@@ -462,7 +489,7 @@ public class SCLAlertView: UIViewController {
 // ------------------------------------
 
 class SCLAlertViewStyleKit : NSObject {
-
+    
     // Cache
     struct Cache {
         static var imageOfCheckmark: UIImage?
@@ -478,12 +505,12 @@ class SCLAlertViewStyleKit : NSObject {
         static var imageOfEdit: UIImage?
         static var editTargets: [AnyObject]?
     }
-
+    
     // Initialization
     /// swift 1.2 abolish func load
-//    override class func load() {
-//    }
-
+    //    override class func load() {
+    //    }
+    
     // Drawing Methods
     class func drawCheckmark() {
         // Checkmark Shape Drawing
@@ -501,11 +528,11 @@ class SCLAlertViewStyleKit : NSObject {
         checkmarkShapePath.addCurveToPoint(CGPointMake(73.25, 14.05), controlPoint1: CGPointMake(75.52, 20.75), controlPoint2: CGPointMake(75.7, 16.65))
         checkmarkShapePath.closePath()
         checkmarkShapePath.miterLimit = 4;
-
+        
         UIColor.whiteColor().setFill()
         checkmarkShapePath.fill()
     }
-
+    
     class func drawCross() {
         // Cross Shape Drawing
         let crossShapePath = UIBezierPath()
@@ -519,7 +546,7 @@ class SCLAlertViewStyleKit : NSObject {
         crossShapePath.lineWidth = 14
         crossShapePath.stroke()
     }
-
+    
     class func drawNotice() {
         // Notice Shape Drawing
         let noticeShapePath = UIBezierPath()
@@ -552,15 +579,15 @@ class SCLAlertViewStyleKit : NSObject {
         noticeShapePath.addCurveToPoint(CGPointMake(72, 48.54), controlPoint1: CGPointMake(71.81, 51.29), controlPoint2: CGPointMake(72, 49.72))
         noticeShapePath.closePath()
         noticeShapePath.miterLimit = 4;
-
+        
         UIColor.whiteColor().setFill()
         noticeShapePath.fill()
     }
-
+    
     class func drawWarning() {
         // Color Declarations
         let greyColor = UIColor(red: 0.236, green: 0.236, blue: 0.236, alpha: 1.000)
-
+        
         // Warning Group
         // Warning Circle Drawing
         let warningCirclePath = UIBezierPath()
@@ -575,11 +602,11 @@ class SCLAlertViewStyleKit : NSObject {
         warningCirclePath.addCurveToPoint(CGPointMake(40.94, 63.39), controlPoint1: CGPointMake(44.53, 64.18), controlPoint2: CGPointMake(42.83, 63.39))
         warningCirclePath.closePath()
         warningCirclePath.miterLimit = 4;
-
+        
         greyColor.setFill()
         warningCirclePath.fill()
-
-
+        
+        
         // Warning Shape Drawing
         let warningShapePath = UIBezierPath()
         warningShapePath.moveToPoint(CGPointMake(46.23, 4.26))
@@ -595,15 +622,15 @@ class SCLAlertViewStyleKit : NSObject {
         warningShapePath.addCurveToPoint(CGPointMake(46.23, 4.26), controlPoint1: CGPointMake(48.5, 7.01), controlPoint2: CGPointMake(47.74, 5.44))
         warningShapePath.closePath()
         warningShapePath.miterLimit = 4;
-
+        
         greyColor.setFill()
         warningShapePath.fill()
     }
-
+    
     class func drawInfo() {
         // Color Declarations
         let color0 = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1.000)
-
+        
         // Info Shape Drawing
         let infoShapePath = UIBezierPath()
         infoShapePath.moveToPoint(CGPointMake(45.66, 15.96))
@@ -625,11 +652,11 @@ class SCLAlertViewStyleKit : NSObject {
         color0.setFill()
         infoShapePath.fill()
     }
-
+    
     class func drawEdit() {
         // Color Declarations
         let color = UIColor(red:1.0, green:1.0, blue:1.0, alpha:1.0)
-
+        
         // Edit shape Drawing
         let editPathPath = UIBezierPath()
         editPathPath.moveToPoint(CGPointMake(71, 2.7))
@@ -672,7 +699,7 @@ class SCLAlertViewStyleKit : NSObject {
         color.setFill()
         editPathPath.fill()
     }
-
+    
     // Generated Images
     class var imageOfCheckmark: UIImage {
         if (Cache.imageOfCheckmark != nil) {
@@ -684,7 +711,7 @@ class SCLAlertViewStyleKit : NSObject {
         UIGraphicsEndImageContext()
         return Cache.imageOfCheckmark!
     }
-
+    
     class var imageOfCross: UIImage {
         if (Cache.imageOfCross != nil) {
             return Cache.imageOfCross!
@@ -695,7 +722,7 @@ class SCLAlertViewStyleKit : NSObject {
         UIGraphicsEndImageContext()
         return Cache.imageOfCross!
     }
-
+    
     class var imageOfNotice: UIImage {
         if (Cache.imageOfNotice != nil) {
             return Cache.imageOfNotice!
@@ -706,7 +733,7 @@ class SCLAlertViewStyleKit : NSObject {
         UIGraphicsEndImageContext()
         return Cache.imageOfNotice!
     }
-
+    
     class var imageOfWarning: UIImage {
         if (Cache.imageOfWarning != nil) {
             return Cache.imageOfWarning!
@@ -717,7 +744,7 @@ class SCLAlertViewStyleKit : NSObject {
         UIGraphicsEndImageContext()
         return Cache.imageOfWarning!
     }
-
+    
     class var imageOfInfo: UIImage {
         if (Cache.imageOfInfo != nil) {
             return Cache.imageOfInfo!
@@ -728,7 +755,7 @@ class SCLAlertViewStyleKit : NSObject {
         UIGraphicsEndImageContext()
         return Cache.imageOfInfo!
     }
-
+    
     class var imageOfEdit: UIImage {
         if (Cache.imageOfEdit != nil) {
             return Cache.imageOfEdit!

--- a/Example/SCLAlertViewExample/SCLAlertView.swift
+++ b/Example/SCLAlertViewExample/SCLAlertView.swift
@@ -160,16 +160,9 @@ public class SCLAlertView: UIViewController {
     
     override public func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        var sz = UIScreen.mainScreen().bounds.size
-        let sver = UIDevice.currentDevice().systemVersion as NSString
-        let ver = sver.floatValue
-        if ver < 8.0 {
-            // iOS versions before 7.0 did not switch the width and height on device roration
-            if UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication().statusBarOrientation) {
-                let ssz = sz
-                sz = CGSize(width:ssz.height, height:ssz.width)
-            }
-        }
+        let rv = UIApplication.sharedApplication().keyWindow! as UIWindow
+        let sz = rv.frame.size
+        
         // Set background frame
         view.frame.size = sz
         

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -160,16 +160,9 @@ public class SCLAlertView: UIViewController {
 
     override public func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        var sz = UIScreen.mainScreen().bounds.size
-        let sver = UIDevice.currentDevice().systemVersion as NSString
-        let ver = sver.floatValue
-        if ver < 8.0 {
-            // iOS versions before 7.0 did not switch the width and height on device roration
-            if UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication().statusBarOrientation) {
-                let ssz = sz
-                sz = CGSize(width:ssz.height, height:ssz.width)
-            }
-        }
+        let rv = UIApplication.sharedApplication().keyWindow! as UIWindow
+        let sz = rv.frame.size
+        
         // Set background frame
         view.frame.size = sz
         


### PR DESCRIPTION
When being used in split-screen mode for iPads, the alert view was not showing up in the center of the view:

![alert not center](https://cloud.githubusercontent.com/assets/10458062/9919381/54d15718-5c81-11e5-8fa6-517a36b072af.png)

This fixes it so the alert view shows up in the center:

![alert center](https://cloud.githubusercontent.com/assets/10458062/9919396/68faf456-5c81-11e5-9438-77b5dd325e53.png)

I also copy/pasted the version of SCLAlertView.swift in the root folder to the one in the example project since they seemed out of sync.
