### PR TITLE
Correct version number

### DIFF
--- a/SCLAlertView/Info.plist
+++ b/SCLAlertView/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
For some reason, apple complains about the version number that should have 3 digits. This lib prevented me from submitting to the appstore. Seems to be a new rule. Anyway, I've changed the version number to the correct one to prevent future problems.