### PR TITLE
ensuring that hideView isnt calling the responder multiple times

### DIFF
--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -309,7 +309,8 @@ public class SCLAlertView: UIViewController {
         } else {
             print("Unknow action type for button")
         }
-        hideView()
+        
+        if(self.view.alpha != 0.0){ hideView() }
     }
     
     


### PR DESCRIPTION
I've incorporated a simple alpha check (like that which is done in the base SCLAlertView obj-c project) to determine whether the corresponding AlertView should be dismissed. This prevents duplicate calls to the hideView func.