### PR TITLE
Add Carthage Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ To install add the following line to your Podfile:
 
     pod 'SCLAlertView'
 
+SCLAlertView is also available through [Carthage](https://github.com/Carthage/Carthage).
+
+To install add the following line to your Cartfile:
+
+    github "vikmeup/SCLAlertView-Swift"
+
 Collaboration
 ---
 

--- a/SCLAlertView.xcodeproj/project.pbxproj
+++ b/SCLAlertView.xcodeproj/project.pbxproj
@@ -363,10 +363,6 @@
 		70264F111B0F588800B32B18 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -380,10 +376,6 @@
 		70264F121B0F588800B32B18 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = SCLAlertViewTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SCLAlertView.xcodeproj/xcshareddata/xcschemes/SCLAlertView.xcscheme
+++ b/SCLAlertView.xcodeproj/xcshareddata/xcschemes/SCLAlertView.xcscheme
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:SCLAlertView.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
I looked into the issues I was also having that are described in #46 

I cloned the repo and was surprised to see the 'SCLAlertView' scheme is already shared.
When I ran a `carthage build --no-skip-current` the framework built fine, with only one warning (hence my changes to the unused Framework Search Paths).

I removed 'Shared' from the scheme, then re-added 'Shared' to the scheme, built the framework and tested using Carthage from my own fork. Must've just been some .xcodeproj voodoo that didn't properly set the scheme as Shared the first time.

This can be tested by adding `github "phillfarrugia/SCLAlertView-Swift' to your Cartfile and running a `carthage update`.