### PR TITLE
Seen some bugs due to keyboard switching

### DIFF
--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -135,6 +135,9 @@ public class SCLAlertView: UIViewController {
     private var buttons = [SCLButton]()
     private var selfReference: SCLAlertView?
     
+    // Bug Alert Going up/down
+    var skeyBoard = 0
+    
     required public init?(coder aDecoder: NSCoder) {
         fatalError("NSCoding not supported")
     }
@@ -355,15 +358,22 @@ public class SCLAlertView: UIViewController {
     var keyboardHasBeenShown:Bool = false
     
     func keyboardWillShow(notification: NSNotification) {
+        print("keyboardWillShow")
         keyboardHasBeenShown = true
         if let userInfo = notification.userInfo {
             if let beginKeyBoardFrame = userInfo[UIKeyboardFrameBeginUserInfoKey]?.CGRectValue.origin.y {
                 if let endKeyBoardFrame = userInfo[UIKeyboardFrameEndUserInfoKey]?.CGRectValue.origin.y {
-                    tmpContentViewFrameOrigin = self.contentView.frame.origin
-                    tmpCircleViewFrameOrigin = self.circleBG.frame.origin
-                    let newContentViewFrameY = beginKeyBoardFrame - endKeyBoardFrame - self.contentView.frame.origin.y
-                    let newBallViewFrameY = self.circleBG.frame.origin.y - newContentViewFrameY
-                    self.contentView.frame.origin.y -= newContentViewFrameY
+                    if skeyBoard == 0 { // SAVE INITIAL POSITION OF THE ALERT FIRST TIME
+                        tmpContentViewFrameOrigin = self.contentView.frame.origin
+                        tmpCircleViewFrameOrigin = self.circleBG.frame.origin
+                        skeyBoard = 1
+                    }
+                    
+                    self.contentView.frame.origin = tmpContentViewFrameOrigin!
+                    self.circleBG.frame.origin = tmpCircleViewFrameOrigin!
+
+                    self.contentView.frame.origin.y = endKeyBoardFrame - self.contentView.frame.size.height - 10 // 10 is abitrary space between keyb and alert
+                    let newBallViewFrameY = self.contentView.frame.origin.y - self.circleBG.frame.size.height / 2
                     self.circleBG.frame.origin.y = newBallViewFrameY
                 }
             }
@@ -371,6 +381,7 @@ public class SCLAlertView: UIViewController {
     }
     
     func keyboardWillHide(notification: NSNotification) {
+        print("keyboardWillHide")
         if(keyboardHasBeenShown){//This could happen on the simulator (keyboard will be hidden)
             if(self.tmpContentViewFrameOrigin != nil){
                 self.contentView.frame.origin.y = self.tmpContentViewFrameOrigin!.y

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -275,7 +275,8 @@ public class SCLAlertView: UIViewController {
         let txt = UITextField()
         txt.borderStyle = UITextBorderStyle.RoundedRect
         txt.font = UIFont(name:kDefaultFont, size: 14)
-        txt.autocapitalizationType = UITextAutocapitalizationType.Words
+        txt.autocapitalizationType = UITextAutocapitalizationType.None
+        txt.autocorrectionType = .No
         txt.clearButtonMode = UITextFieldViewMode.WhileEditing
         txt.layer.masksToBounds = true
         txt.layer.borderWidth = 1.0

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -358,7 +358,6 @@ public class SCLAlertView: UIViewController {
     var keyboardHasBeenShown:Bool = false
     
     func keyboardWillShow(notification: NSNotification) {
-        print("keyboardWillShow")
         keyboardHasBeenShown = true
         if let userInfo = notification.userInfo {
             if let beginKeyBoardFrame = userInfo[UIKeyboardFrameBeginUserInfoKey]?.CGRectValue.origin.y {
@@ -381,7 +380,6 @@ public class SCLAlertView: UIViewController {
     }
     
     func keyboardWillHide(notification: NSNotification) {
-        print("keyboardWillHide")
         if(keyboardHasBeenShown){//This could happen on the simulator (keyboard will be hidden)
             if(self.tmpContentViewFrameOrigin != nil){
                 self.contentView.frame.origin.y = self.tmpContentViewFrameOrigin!.y


### PR DESCRIPTION
Whenever the func keyboardWillShow is called, the alert was moving not relative to its basic position but with its present position.

Just try switching between emoji and qwerty keyboards, you'll see. I think it's the same problem for multiple textfields : every time you click on a field, it calls the keyboardWillShow func moving the alert... again... and again... and again :)

In the fact, the alert go outside of the screen and never comeback, and block the user with an alert he can't dismiss

By the way i put text field autocapitalisation default to None and disable autocorrection/suggestion to .No, it was just needed for me atm but it doesn't matter.