### PR TITLE
Swift 2.2 update - Color conversion refactor

### DIFF
--- a/Example/SCLAlertViewExample/ViewController.swift
+++ b/Example/SCLAlertViewExample/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
     
     @IBAction func showSuccess(sender: AnyObject) {
 		let alert = SCLAlertView()
-		alert.addButton("First Button", target:self, selector:Selector("firstButton"))
+		alert.addButton("First Button", target:self, selector:#selector(ViewController.firstButton))
 		alert.addButton("Second Button") {
 			print("Second button tapped")
 		}

--- a/SCLAlertView.xcodeproj/project.pbxproj
+++ b/SCLAlertView.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		9E124F1B1C9EA303001A4972 /* SCLAlertViewInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E124F1A1C9EA303001A4972 /* SCLAlertViewInitTests.swift */; };
 		9E124F1D1C9EA6B5001A4972 /* SCLTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E124F1C1C9EA6B5001A4972 /* SCLTextFieldTests.swift */; };
 		9E47417F1CA1DABE00F95B05 /* SCLButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E47417E1CA1DABE00F95B05 /* SCLButtonTests.swift */; };
+		9EAEFBC51CC2AA6600BA87FB /* SCLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAEFBC41CC2AA6600BA87FB /* SCLExtensions.swift */; };
 		9EE073151C9D7F4C002B43FD /* SCLAlertViewPropertiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE073131C9D7F4C002B43FD /* SCLAlertViewPropertiesTests.swift */; };
 		9EE073161C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE073141C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift */; };
 		9EE073171C9D7F6B002B43FD /* SCLAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70264F171B0F592500B32B18 /* SCLAlertView.swift */; };
@@ -41,6 +42,7 @@
 		9E124F1A1C9EA303001A4972 /* SCLAlertViewInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLAlertViewInitTests.swift; sourceTree = "<group>"; };
 		9E124F1C1C9EA6B5001A4972 /* SCLTextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLTextFieldTests.swift; sourceTree = "<group>"; };
 		9E47417E1CA1DABE00F95B05 /* SCLButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLButtonTests.swift; sourceTree = "<group>"; };
+		9EAEFBC41CC2AA6600BA87FB /* SCLExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLExtensions.swift; sourceTree = "<group>"; };
 		9EE073131C9D7F4C002B43FD /* SCLAlertViewPropertiesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLAlertViewPropertiesTests.swift; sourceTree = "<group>"; };
 		9EE073141C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLAlertViewStyleTests.swift; sourceTree = "<group>"; };
 		9EE99F901CA6B2320090F845 /* SCLPublicConstructorsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLPublicConstructorsTest.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				70264F171B0F592500B32B18 /* SCLAlertView.swift */,
+				9EAEFBC41CC2AA6600BA87FB /* SCLExtensions.swift */,
 				70264EFA1B0F588700B32B18 /* Supporting Files */,
 			);
 			path = SCLAlertView;
@@ -234,6 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9EAEFBC51CC2AA6600BA87FB /* SCLExtensions.swift in Sources */,
 				70264F181B0F592500B32B18 /* SCLAlertView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SCLAlertView.xcodeproj/project.pbxproj
+++ b/SCLAlertView.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9EE073151C9D7F4C002B43FD /* SCLAlertViewPropertiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE073131C9D7F4C002B43FD /* SCLAlertViewPropertiesTests.swift */; };
 		9EE073161C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE073141C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift */; };
 		9EE073171C9D7F6B002B43FD /* SCLAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70264F171B0F592500B32B18 /* SCLAlertView.swift */; };
+		9EE99F911CA6B2320090F845 /* SCLPublicConstructorsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE99F901CA6B2320090F845 /* SCLPublicConstructorsTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,6 +43,7 @@
 		9E47417E1CA1DABE00F95B05 /* SCLButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLButtonTests.swift; sourceTree = "<group>"; };
 		9EE073131C9D7F4C002B43FD /* SCLAlertViewPropertiesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLAlertViewPropertiesTests.swift; sourceTree = "<group>"; };
 		9EE073141C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLAlertViewStyleTests.swift; sourceTree = "<group>"; };
+		9EE99F901CA6B2320090F845 /* SCLPublicConstructorsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCLPublicConstructorsTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +112,7 @@
 				9EE073141C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift */,
 				9E124F1C1C9EA6B5001A4972 /* SCLTextFieldTests.swift */,
 				9E47417E1CA1DABE00F95B05 /* SCLButtonTests.swift */,
+				9EE99F901CA6B2320090F845 /* SCLPublicConstructorsTest.swift */,
 				70264F071B0F588800B32B18 /* Supporting Files */,
 			);
 			path = SCLAlertViewTests;
@@ -241,6 +244,7 @@
 			files = (
 				9E47417F1CA1DABE00F95B05 /* SCLButtonTests.swift in Sources */,
 				9EE073151C9D7F4C002B43FD /* SCLAlertViewPropertiesTests.swift in Sources */,
+				9EE99F911CA6B2320090F845 /* SCLPublicConstructorsTest.swift in Sources */,
 				9EE073161C9D7F4C002B43FD /* SCLAlertViewStyleTests.swift in Sources */,
 				9E124F1D1C9EA6B5001A4972 /* SCLTextFieldTests.swift in Sources */,
 				9E124F1B1C9EA303001A4972 /* SCLAlertViewInitTests.swift in Sources */,

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -179,12 +179,12 @@ public class SCLAlertView: UIViewController {
         viewText.textContainer.lineFragmentPadding = 0;
         viewText.font = UIFont(name: kDefaultFont, size:14)
         // Colours
-        contentView.backgroundColor = UIColorFromRGB(0xFFFFFF)
-        labelTitle.textColor = UIColorFromRGB(0x4D4D4D)
-        viewText.textColor = UIColorFromRGB(0x4D4D4D)
-        contentView.layer.borderColor = UIColorFromRGB(0xCCCCCC).CGColor
+        contentView.backgroundColor = 0xFFFFFF.toUIColor()
+        labelTitle.textColor = 0x4D4D4D.toUIColor()
+        viewText.textColor = 0x4D4D4D.toUIColor()
+        contentView.layer.borderColor = 0xCCCCCC.toCGColor()
         //Gesture Recognizer for tapping outside the textinput
-        let tapGesture = UITapGestureRecognizer(target: self, action: Selector("tapped:"))
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(SCLAlertView.tapped(_:)))
         tapGesture.numberOfTapsRequired = 1
         self.view.addGestureRecognizer(tapGesture)
     }
@@ -255,8 +255,8 @@ public class SCLAlertView: UIViewController {
     
     override public func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("keyboardWillShow:"), name:UIKeyboardWillShowNotification, object: nil);
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("keyboardWillHide:"), name:UIKeyboardWillHideNotification, object: nil);
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(SCLAlertView.keyboardWillShow(_:)), name:UIKeyboardWillShowNotification, object: nil);
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(SCLAlertView.keyboardWillHide(_:)), name:UIKeyboardWillHideNotification, object: nil);
     }
     
     override public func viewDidDisappear(animated: Bool) {
@@ -294,9 +294,9 @@ public class SCLAlertView: UIViewController {
         let btn = addButton(title)
         btn.actionType = SCLActionType.Closure
         btn.action = action
-        btn.addTarget(self, action:Selector("buttonTapped:"), forControlEvents:.TouchUpInside)
-        btn.addTarget(self, action:Selector("buttonTapDown:"), forControlEvents:[.TouchDown, .TouchDragEnter])
-        btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:[.TouchUpInside, .TouchUpOutside, .TouchCancel, .TouchDragOutside] )
+        btn.addTarget(self, action:#selector(SCLAlertView.buttonTapped(_:)), forControlEvents:.TouchUpInside)
+        btn.addTarget(self, action:#selector(SCLAlertView.buttonTapDown(_:)), forControlEvents:[.TouchDown, .TouchDragEnter])
+        btn.addTarget(self, action:#selector(SCLAlertView.buttonRelease(_:)), forControlEvents:[.TouchUpInside, .TouchUpOutside, .TouchCancel, .TouchDragOutside] )
         return btn
     }
     
@@ -305,9 +305,9 @@ public class SCLAlertView: UIViewController {
         btn.actionType = SCLActionType.Selector
         btn.target = target
         btn.selector = selector
-        btn.addTarget(self, action:Selector("buttonTapped:"), forControlEvents:.TouchUpInside)
-        btn.addTarget(self, action:Selector("buttonTapDown:"), forControlEvents:[.TouchDown, .TouchDragEnter])
-        btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:[.TouchUpInside, .TouchUpOutside, .TouchCancel, .TouchDragOutside] )
+        btn.addTarget(self, action:#selector(SCLAlertView.buttonTapped(_:)), forControlEvents:.TouchUpInside)
+        btn.addTarget(self, action:#selector(SCLAlertView.buttonTapDown(_:)), forControlEvents:[.TouchDown, .TouchDragEnter])
+        btn.addTarget(self, action:#selector(SCLAlertView.buttonRelease(_:)), forControlEvents:[.TouchUpInside, .TouchUpOutside, .TouchCancel, .TouchDragOutside] )
         return btn
     }
     
@@ -358,18 +358,17 @@ public class SCLAlertView: UIViewController {
     
     func keyboardWillShow(notification: NSNotification) {
         keyboardHasBeenShown = true
-        if let userInfo = notification.userInfo {
-            if let beginKeyBoardFrame = userInfo[UIKeyboardFrameBeginUserInfoKey]?.CGRectValue.origin.y {
-                if let endKeyBoardFrame = userInfo[UIKeyboardFrameEndUserInfoKey]?.CGRectValue.origin.y {
-                    tmpContentViewFrameOrigin = self.contentView.frame.origin
-                    tmpCircleViewFrameOrigin = self.circleBG.frame.origin
-                    let newContentViewFrameY = beginKeyBoardFrame - endKeyBoardFrame - self.contentView.frame.origin.y
-                    let newBallViewFrameY = self.circleBG.frame.origin.y - newContentViewFrameY
-                    self.contentView.frame.origin.y -= newContentViewFrameY
-                    self.circleBG.frame.origin.y = newBallViewFrameY
-                }
-            }
-        }
+        
+        guard let userInfo = notification.userInfo else {return}
+        guard let beginKeyBoardFrame = userInfo[UIKeyboardFrameBeginUserInfoKey]?.CGRectValue.origin.y else {return}
+        guard let endKeyBoardFrame = userInfo[UIKeyboardFrameEndUserInfoKey]?.CGRectValue.origin.y else {return}
+        
+        tmpContentViewFrameOrigin = self.contentView.frame.origin
+        tmpCircleViewFrameOrigin = self.circleBG.frame.origin
+        let newContentViewFrameY = beginKeyBoardFrame - endKeyBoardFrame - self.contentView.frame.origin.y
+        let newBallViewFrameY = self.circleBG.frame.origin.y - newContentViewFrameY
+        self.contentView.frame.origin.y -= newContentViewFrameY
+        self.circleBG.frame.origin.y = newBallViewFrameY
     }
     
     func keyboardWillHide(notification: NSNotification) {
@@ -447,7 +446,7 @@ public class SCLAlertView: UIViewController {
         viewColor = UIColor()
         var iconImage: UIImage?
         let colorInt = colorStyle ?? style.defaultColorInt
-        viewColor = UIColorFromRGB(colorInt)
+        viewColor = colorInt.toUIColor()
         // Icon style
         switch style {
         case .Success:
@@ -501,7 +500,7 @@ public class SCLAlertView: UIViewController {
         // Done button
         if showCloseButton {
             let txt = completeText != nil ? completeText! : "Done"
-            addButton(txt, target:self, selector:Selector("hideView"))
+            addButton(txt, target:self, selector:#selector(SCLAlertView.hideView))
         }
         
         //hidden/show circular view based on the ui option
@@ -528,13 +527,13 @@ public class SCLAlertView: UIViewController {
         }
         for btn in buttons {
             btn.backgroundColor = viewColor
-            btn.setTitleColor(UIColorFromRGB(colorTextButton ?? 0xFFFFFF), forState:UIControlState.Normal)
+            btn.setTitleColor(colorTextButton?.toUIColor() ?? 0xFFFFFF.toUIColor(), forState:UIControlState.Normal)
         }
         
         // Adding duration
         if duration > 0 {
             durationTimer?.invalidate()
-            durationTimer = NSTimer.scheduledTimerWithTimeInterval(duration!, target: self, selector: Selector("hideView"), userInfo: nil, repeats: false)
+            durationTimer = NSTimer.scheduledTimerWithTimeInterval(duration!, target: self, selector: #selector(SCLAlertView.hideView), userInfo: nil, repeats: false)
         }
         
         // Animate in the alert view
@@ -580,16 +579,6 @@ public class SCLAlertView: UIViewController {
         } else {
             return defaultImage
         }
-    }
-    
-    // Helper function to convert from RGB to UIColor
-    func UIColorFromRGB(rgbValue: UInt) -> UIColor {
-        return UIColor(
-            red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
-            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
-            blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
-            alpha: CGFloat(1.0)
-        )
     }
 }
 

--- a/SCLAlertView/SCLExtensions.swift
+++ b/SCLAlertView/SCLExtensions.swift
@@ -1,0 +1,41 @@
+//
+//  SCLExtensions.swift
+//  SCLAlertView
+//
+//  Created by Christian Cabarrocas on 16/04/16.
+//  Copyright © 2016 Alexey Poimtsev. All rights reserved.
+//
+
+import UIKit
+
+extension Int {
+    
+    func toUIColor() -> UIColor {
+        return UIColor(
+            red: CGFloat((self & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((self & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(self & 0x0000FF) / 255.0,
+            alpha: CGFloat(1.0)
+        )
+    }
+    
+    func toCGColor() -> CGColor {
+        return self.toUIColor().CGColor
+    }
+}
+
+extension UInt {
+    
+    func toUIColor() -> UIColor {
+        return UIColor(
+            red: CGFloat((self & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((self & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(self & 0x0000FF) / 255.0,
+            alpha: CGFloat(1.0)
+        )
+    }
+    
+    func toCGColor() -> CGColor {
+        return self.toUIColor().CGColor
+    }
+}

--- a/SCLAlertViewTests/SCLButtonTests.swift
+++ b/SCLAlertViewTests/SCLButtonTests.swift
@@ -54,7 +54,7 @@ class SCLButtonTests: XCTestCase {
     
     func testButtonTargets() {
         let alert = SCLAlertView()
-        alert.addButton("testButtontitle") {}
+        alert.addButton("testButtonTitle") {}
         let buttonTargets = alert.buttons[0].allTargets().first
         let button = alert.buttons[0]
         
@@ -78,6 +78,18 @@ class SCLButtonTests: XCTestCase {
         XCTAssertTrue(buttonActionsTouchUpOutside![0] == "buttonRelease:")
     }
     
+    func testButtonSelectorAndTarget() {
+        let alert = SCLAlertView()
+        let testTarget = SCLAlertView()
+        let testSelector = Selector()
+        alert.addButton("testButtonTitle", target: testTarget, selector: testSelector)
+        let button = alert.buttons[0]
+        XCTAssertTrue(button.target.isKindOfClass(SCLAlertView.self))
+        XCTAssertTrue(button.selector == testSelector)
+        XCTAssertTrue(button.actionType == SCLActionType.Selector)
+        
+    }
+    
     func testButtonActionType() {
         let alert = SCLAlertView()
         alert.addButton("testButtonTitle") {}
@@ -85,14 +97,3 @@ class SCLButtonTests: XCTestCase {
         XCTAssertTrue(button.actionType == SCLActionType.Closure)
     }
 }
-
-
-//public func addButton(title:String, action:()->Void)->SCLButton {
-//    let btn = addButton(title)
-//    btn.actionType = SCLActionType.Closure
-//    btn.action = action
-//    btn.addTarget(self, action:Selector("buttonTapped:"), forControlEvents:.TouchUpInside)
-//    btn.addTarget(self, action:Selector("buttonTapDown:"), forControlEvents:[.TouchDown, .TouchDragEnter])
-//    btn.addTarget(self, action:Selector("buttonRelease:"), forControlEvents:[.TouchUpInside, .TouchUpOutside, .TouchCancel, .TouchDragOutside] )
-//    return btn
-//}

--- a/SCLAlertViewTests/SCLPublicConstructorsTest.swift
+++ b/SCLAlertViewTests/SCLPublicConstructorsTest.swift
@@ -1,0 +1,60 @@
+//
+//  SCLPublicConstructorsTest.swift
+//  SCLAlertView
+//
+//  Created by Christian Cabarrocas on 26/03/16.
+//  Copyright © 2016 Alexey Poimtsev. All rights reserved.
+//
+
+import XCTest
+
+class SCLPublicConstructorsTest: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testShowSuccess() {
+        let image = UIImage()
+        let alert = SCLAlertView()
+        let successReturn = alert.showSuccess("testTitle", subTitle: "testSubTitle", closeButtonTitle: "testClosebutton", duration: 1.0, colorStyle: 1, colorTextButton: 1, circleIconImage: image)
+        XCTAssertNotNil(successReturn)
+    }
+
+}
+
+
+
+/*
+public func showSuccess(title: String, subTitle: String, closeButtonTitle:String?=nil, duration:NSTimeInterval=0.0, colorStyle: UInt=SCLAlertViewStyle.Success.defaultColorInt, colorTextButton: UInt=0xFFFFFF, circleIconImage: UIImage? = nil) -> SCLAlertViewResponder {
+return showTitle(title, subTitle: subTitle, duration: duration, completeText:closeButtonTitle, style: .Success, colorStyle: colorStyle, colorTextButton: colorTextButton, circleIconImage: circleIconImage)
+}
+
+public class SCLAlertViewResponder {
+let alertview: SCLAlertView
+
+// Initialisation and Title/Subtitle/Close functions
+public init(alertview: SCLAlertView) {
+self.alertview = alertview
+}
+
+public func setTitle(title: String) {
+self.alertview.labelTitle.text = title
+}
+
+public func setSubTitle(subTitle: String) {
+self.alertview.viewText.text = subTitle
+}
+
+public func close() {
+self.alertview.hideView()
+}
+
+public func setDismissBlock(dismissBlock: DismissBlock) {
+self.alertview.dismissBlock = dismissBlock
+}
+*/


### PR DESCRIPTION
Update selectors to Swift 2.2 syntax
Color conversion refactor to extensions to make it more testable