### PR TITLE
Fixed keyboardWillShow() and enabled button click color

### DIFF
--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -32,7 +32,7 @@ public enum SCLAlertViewStyle {
         }
         
     }
-
+    
 }
 
 // Action Types
@@ -177,7 +177,7 @@ public class SCLAlertView: UIViewController {
     public var iconTintColor: UIColor?
     public var customSubview : UIView?
     
-
+    
     
     // Members declaration
     var baseView = UIView()
@@ -381,7 +381,7 @@ public class SCLAlertView: UIViewController {
         appearance.setkWindowHeight(appearance.kWindowHeight + appearance.kTextViewdHeight)
         // Add text view
         let txt = UITextView()
-        // No placeholder with UITextView but you can use KMPlaceholderTextView library 
+        // No placeholder with UITextView but you can use KMPlaceholderTextView library
         txt.font = appearance.kTextFont
         //txt.autocapitalizationType = UITextAutocapitalizationType.Words
         //txt.clearButtonMode = UITextFieldViewMode.WhileEditing
@@ -449,13 +449,14 @@ public class SCLAlertView: UIViewController {
         var saturation : CGFloat = 0
         var brightness : CGFloat = 0
         var alpha : CGFloat = 0
+        var pressBrightnessFactor = 0.85
         btn.backgroundColor?.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
-        //brightness = brightness * CGFloat(pressBrightness)
+        brightness = brightness * CGFloat(pressBrightnessFactor)
         btn.backgroundColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: alpha)
     }
     
     func buttonRelease(btn:SCLButton) {
-        btn.backgroundColor = viewColor
+        btn.backgroundColor = btn.customBackgroundColor
     }
     
     var tmpContentViewFrameOrigin: CGPoint?
@@ -466,12 +467,20 @@ public class SCLAlertView: UIViewController {
         keyboardHasBeenShown = true
         
         guard let userInfo = notification.userInfo else {return}
-        guard let beginKeyBoardFrame = userInfo[UIKeyboardFrameBeginUserInfoKey]?.CGRectValue.origin.y else {return}
-        guard let endKeyBoardFrame = userInfo[UIKeyboardFrameEndUserInfoKey]?.CGRectValue.origin.y else {return}
+        guard let endKeyBoardFrame = userInfo[UIKeyboardFrameEndUserInfoKey]?.CGRectValue.minY else {return}
         
-        tmpContentViewFrameOrigin = self.contentView.frame.origin
-        tmpCircleViewFrameOrigin = self.circleBG.frame.origin
-        let newContentViewFrameY = beginKeyBoardFrame - endKeyBoardFrame - self.contentView.frame.origin.y
+        if tmpContentViewFrameOrigin == nil {
+            tmpContentViewFrameOrigin = self.contentView.frame.origin
+        }
+        
+        if tmpCircleViewFrameOrigin == nil {
+            tmpCircleViewFrameOrigin = self.circleBG.frame.origin
+        }
+        
+        var newContentViewFrameY = self.contentView.frame.maxY - endKeyBoardFrame
+        if newContentViewFrameY < 0 {
+            newContentViewFrameY = 0
+        }
         let newBallViewFrameY = self.circleBG.frame.origin.y - newContentViewFrameY
         self.contentView.frame.origin.y -= newContentViewFrameY
         self.circleBG.frame.origin.y = newBallViewFrameY
@@ -481,9 +490,11 @@ public class SCLAlertView: UIViewController {
         if(keyboardHasBeenShown){//This could happen on the simulator (keyboard will be hidden)
             if(self.tmpContentViewFrameOrigin != nil){
                 self.contentView.frame.origin.y = self.tmpContentViewFrameOrigin!.y
+                self.tmpContentViewFrameOrigin = nil
             }
             if(self.tmpCircleViewFrameOrigin != nil){
                 self.circleBG.frame.origin.y = self.tmpCircleViewFrameOrigin!.y
+                self.tmpCircleViewFrameOrigin = nil
             }
             
             keyboardHasBeenShown = false


### PR DESCRIPTION
keyboardWillShow and keyboardWillHide will only store original copy of tmpContentViewFrameOrigin.
This prevents custom keyboards that call multiple keyboardWillShow messing up the layout.
Also changed keyboardWillShow placement of the alertbox to the following:
1. if keyboard doesn't overlap with content view, then nothing gets moved
2. if keyboard overlaps with content view, then content view shifts up to a limit of 10 pts from the
   top, this makes sure the top of the alert box is always showing with nice margine.

I also enabled button shading, so now when you press and hold, the button goes a bit darker and restores
to previous color when you let go.