### PR TITLE
No longer call dismissBlock twice when alert view is hidden using cancelButton

### DIFF
--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -707,6 +707,8 @@ public class SCLAlertView: UIViewController {
             self.view.alpha = 0
             }, completion: { finished in
                 
+                //Stop durationTimer so alertView does not attempt to hide itself and fire it's dimiss block a second time when close button is tapped
+                self.durationTimer?.invalidate()
                 // Stop StatusTimer
                 self.durationStatusTimer?.invalidate()
                 


### PR DESCRIPTION
When the alert view was being cancelled using the provided button it would hide the view and call the dismiss block, then the durationTimer would fire and hide the view and call the dismiss block a second time. The hide function now invalidates the durationTimer as well so that the hide function is not called a second time.