### PR TITLE
added circular radius to the circleIconView layer

### DIFF
--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -671,6 +671,8 @@ public class SCLAlertView: UIViewController {
         circleView.addSubview(circleIconView!)
         let x = (appearance.kCircleHeight - appearance.kCircleIconHeight) / 2
         circleIconView!.frame = CGRectMake( x, x, appearance.kCircleIconHeight, appearance.kCircleIconHeight)
+        circleIconView?.layer.cornerRadius = circleIconView!.bounds.height / 2
+        circleIconView?.layer.masksToBounds = true
         
         for txt in inputs {
             txt.layer.borderColor = viewColor.CGColor


### PR DESCRIPTION
The circular radius allows custom icons to be masked accordingly to its circular container view (and does not interfere or modify with the default icons that are drawn). Two lines added after line 673 in SCLAlertView.swift.
The user would have to set kCircleIconHeight in the SCLAppearance setup, as expected to implement a custom icon for the circleIconView. Setting kCircleIconHeight: CGFloat(56.0) matches the default kCircleHeight and covers the drawn circle. A smaller circle height will allow the drawn circle to show through as a coloured ring, if such an effect is desired.