### PR TITLE
Fixed dismiss block setter to comply with the latest Swift3 syntax

### DIFF
--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -111,7 +111,7 @@ open class SCLAlertViewResponder {
         self.alertview.hideView()
     }
     
-    open func setDismissBlock(_ dismissBlock: DismissBlock) {
+    open func setDismissBlock(_ dismissBlock: @escaping DismissBlock) {
         self.alertview.dismissBlock = dismissBlock
     }
 }


### PR DESCRIPTION
With Xcode 8 GM SCLAlertView is not working anymore. I've fixed the compile time error.