### PR TITLE
Fix to README.md markdown style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ alert.showInfo("Login", subTitle: "", duration: 10)
 
 #### List of properties to customize
 
-````swift
+```swift
 // Button 
 kButtonFont: UIFont                     
 buttonCornerRadius : CGFloat            


### PR DESCRIPTION
### Abstract
Fix to README.md markdown style.

-------

### Details of cause
https://github.com/vikmeup/SCLAlertView-Swift/blame/master/README.md#L195

<img width="743" alt="readme md blame" src="https://cloud.githubusercontent.com/assets/4126751/24666939/9e8690a6-199c-11e7-8603-51826dbf2102.png">

↑ Typo miss or github markdown specification has been changed?

------

### Before (current README.md)
<img width="701" alt="before md" src="https://cloud.githubusercontent.com/assets/4126751/24667027/eb65c77a-199c-11e7-8c2d-312a9feb57fe.png">


------

### After (Fix to markdown miss style)
<img width="711" alt="after md" src="https://cloud.githubusercontent.com/assets/4126751/24667035/f23f70f0-199c-11e7-933c-457c2766c419.png">
