### PR TITLE
[Fix] Dynamic UITextView Height

### DIFF
--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -412,7 +412,7 @@ open class SCLAlertView: UIViewController {
             y += appearance.kTextFieldHeight
         }
         for txt in input {
-            txt.frame = CGRect(x:hMargin, y:y, width:appearance.kWindowWidth - hMargin * 2, height:70)
+            txt.frame = CGRect(x:hMargin, y:y, width:appearance.kWindowWidth - hMargin * 2, height:appearance.kTextViewdHeight - hMargin)
             //txt.layer.cornerRadius = fieldCornerRadius
             y += appearance.kTextViewdHeight
         }


### PR DESCRIPTION
In this PR, I fixed issue #306 where an alert with a UITextView would always remain a static `70.0` height.

This fix takes into account the value you set with `kTextViewdHeight` within `SCLAppearance`.