### PR TITLE
Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SCLAlertView().showTitle(
     subTitle: "Operation successfully completed.", // String of view
     duration: 2.0, // Duration to show before closing automatically, default: 0.0
     completeText: "Done", // Optional button value, default: ""
-    style: .Success, // Styles - see below.
+    style: .success, // Styles - see below.
     colorStyle: 0xA429FF,
     colorTextButton: 0xFFFFFF
 )


### PR DESCRIPTION
`style: .Succes` was changed to `style: .succes`