### PR TITLE
Fix Carthage error

### DIFF
--- a/SCLAlertViewTests/SCLAlertViewPropertiesTests.swift
+++ b/SCLAlertViewTests/SCLAlertViewPropertiesTests.swift
@@ -42,10 +42,6 @@ class SCLAlertViewPropertiesTests: XCTestCase {
         XCTAssertTrue(alert.appearance.kCircleIconHeight == 20.0)
     }
     
-    func testSCLAlertViewTitleTop() {
-        XCTAssertTrue(alert.appearance.kTitleTop == 30.0)
-    }
-    
     func testSCLAlertViewTitleHeight() {
         XCTAssertTrue(alert.appearance.kTitleHeight == 40.0)
     }


### PR DESCRIPTION
Fix this error when trying to install with carthage:

*** Fetching SCLAlertView-Swift
*** Checking out SCLAlertView-Swift at "3b04846a962d2ab70ed2da3dbc9638600146b38a"
*** xcodebuild output can be found in /var/folders/_l/hbzfgl255vl7kl5k4y0rfq780000gq/T/carthage-xcodebuild.tmH6L3.log
*** Building scheme "SCLAlertView" in SCLAlertView.xcworkspace
Build Failed
Task failed with exit code 65: