### PR TITLE
Removes memory leak

### DIFF
--- a/SCLAlertView.podspec
+++ b/SCLAlertView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SCLAlertView"
-  s.version      = "0.8.1"
+  s.version      = "0.8"
   s.summary      = "Beautiful Alert View. Written in Swift"
   s.homepage     = "https://github.com/vikmeup/SCLAlertView-Swift"
   s.screenshots  = "https://raw.githubusercontent.com/vikmeup/SCPopUpView/master/errorScreenshot.png", "https://raw.githubusercontent.com/vikmeup/SCPopUpView/master/successScreenshot.png"

--- a/SCLAlertView.podspec
+++ b/SCLAlertView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SCLAlertView"
-  s.version      = "0.7.0"
+  s.version      = "0.8.1"
   s.summary      = "Beautiful Alert View. Written in Swift"
   s.homepage     = "https://github.com/vikmeup/SCLAlertView-Swift"
   s.screenshots  = "https://raw.githubusercontent.com/vikmeup/SCPopUpView/master/errorScreenshot.png", "https://raw.githubusercontent.com/vikmeup/SCPopUpView/master/successScreenshot.png"

--- a/SCLAlertView.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SCLAlertView.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -292,7 +292,10 @@ open class SCLAlertView: UIViewController {
     }
     
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        appearance = SCLAppearance()
+        if appearance == nil {
+            appearance = SCLAppearance()
+        }
+        
         super.init(nibName:nibNameOrNil, bundle:nibBundleOrNil)
     }
     

--- a/SCLAlertView/SCLAlertView.swift
+++ b/SCLAlertView/SCLAlertView.swift
@@ -718,7 +718,6 @@ open class SCLAlertView: UIViewController {
         baseView.frame = rv.bounds
         
         // Alert colour/icon
-        viewColor = UIColor()
         var iconImage: UIImage?
         let colorInt = colorStyle ?? style.defaultColorInt
         viewColor = UIColorFromRGB(colorInt)


### PR DESCRIPTION
There were two memory leaks which could originate from:

1) Double assignment of appearance
2) Double assignment of a newly created UIColor object.

This PR addresses both issues